### PR TITLE
    Replace annotation variables and values to more meaningful names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
 # v0.0.8
 * Address review comments.
   Madhu Rajanna <mrajanna@redhat.com>
+
 # v0.0.7
 * Address review comments.
   Humble Chirammal <hchiramm@redhat.com>
+
 # v0.0.6	
 * Update deployment artifacts to v0.0.6 tag.
   Humble Chirammal <hchiramm@redhat.com>
+
 # v0.0.1	
 * Initial drop of GlusterFS CSI driver with GD2 API.
   Humble Chirammal <hchiramm@redhat.com>

--- a/cmd/glusterfs/main.go
+++ b/cmd/glusterfs/main.go
@@ -52,7 +52,7 @@ func handle(config *utils.Config) {
 	}
 	d := gfd.New(config)
 	if d == nil {
-		fmt.Println("Failed to initialize driver")
+		fmt.Println("Failed to initialize GlusterFS CSI driver")
 		os.Exit(1)
 	}
 	d.Run()

--- a/pkg/glusterfs/controllerserver.go
+++ b/pkg/glusterfs/controllerserver.go
@@ -17,8 +17,7 @@ import (
 )
 
 const (
-	glusterDescAnn            = "GlusterFS-CSI"
-	glusterDescAnnValue       = "gluster.org/glusterfs-csi"
+	volumeOwnerAnn            = "VolumeOwner"
 	defaultVolumeSize   int64 = 1000 * utils.MB // default volume size ie 1 GB
 	defaultReplicaCount       = 3
 )
@@ -136,7 +135,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	// If volume does not exist, provision volume
 	glog.V(4).Infof("Received request to create/provision volume name:%s with size:%d", volumeName, volSizeMB)
 	volMetaMap := make(map[string]string)
-	volMetaMap[glusterDescAnn] = glusterDescAnnValue
+	volMetaMap[volumeOwnerAnn] = glusterfsCSIDriverName
 	volumeReq := api.VolCreateReq{
 		Name:         volumeName,
 		Metadata:     volMetaMap,
@@ -205,8 +204,8 @@ func (cs *ControllerServer) checkExistingVolume(volumeName string, volSizeMB int
 	}
 
 	// Do the owner validation
-	if glusterAnnVal, found := vol.Info.Metadata[glusterDescAnn]; found {
-		if glusterAnnVal != glusterDescAnnValue {
+	if glusterAnnVal, found := vol.Info.Metadata[volumeOwnerAnn]; found {
+		if glusterAnnVal != glusterfsCSIDriverName {
 			return "", nil, status.Errorf(codes.Internal, "volume %s (%s) is not owned by Gluster CSI driver",
 				vol.Info.Name, vol.Info.Metadata)
 		}

--- a/pkg/glusterfs/driver.go
+++ b/pkg/glusterfs/driver.go
@@ -9,8 +9,8 @@ import (
 )
 
 const (
-	driverName    = "org.gluster.glusterfs"
-	vendorVersion = "0.0.7"
+	glusterfsCSIDriverName    = "org.gluster.glusterfs"
+	glusterfsCSIDriverVersion = "0.0.8"
 )
 
 //CSI Driver for glusterfs

--- a/pkg/glusterfs/driver_test.go
+++ b/pkg/glusterfs/driver_test.go
@@ -77,13 +77,13 @@ func TestDriverSuite(t *testing.T) {
 				resp[0] = api.VolumeGetResp{
 					ID:       id,
 					Name:     "test1",
-					Metadata: map[string]string{glusterDescAnn: glusterDescAnnValue},
+					Metadata: map[string]string{volumeOwnerAnn: glusterfsCSIDriverName},
 				}
 
 				resp = append(resp, api.VolumeGetResp{
 					ID:       id,
 					Name:     "test1",
-					Metadata: map[string]string{glusterDescAnn: glusterDescAnnValue},
+					Metadata: map[string]string{volumeOwnerAnn: glusterfsCSIDriverName},
 				})
 				writeResp(w, http.StatusOK, resp, t)
 				volumeCache["test1"] = 1000
@@ -97,7 +97,7 @@ func TestDriverSuite(t *testing.T) {
 					Info: api.VolumeInfo{
 						ID:       id,
 						Name:     vol[2],
-						Metadata: map[string]string{glusterDescAnn: glusterDescAnnValue},
+						Metadata: map[string]string{volumeOwnerAnn: glusterfsCSIDriverName},
 					},
 					Online: true,
 					Size: api.SizeInfo{

--- a/pkg/glusterfs/identityserver.go
+++ b/pkg/glusterfs/identityserver.go
@@ -14,8 +14,8 @@ type IdentityServer struct {
 // GetPluginInfo returns metadata of the plugin
 func (is *IdentityServer) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
 	resp := &csi.GetPluginInfoResponse{
-		Name:          driverName,
-		VendorVersion: vendorVersion,
+		Name:          glusterfsCSIDriverName,
+		VendorVersion: glusterfsCSIDriverVersion,
 	}
 	glog.V(1).Infof("%+v, plugininfo response: %+v", resp)
 	return resp, nil


### PR DESCRIPTION
This PR replaces `glusterDescAnn` to `volumeOwnerAnn` and remove `glusterDescAnnValue` to make use of one driver name across servers.


Signed-off-by: Humble Chirammal <hchiramm@redhat.com>