### PR TITLE
Remove the OWNERS file.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,0 @@
-approvers:
-  - humblec
-  - JohnStrunk
-reviewers
-  - JohnStrunk
-  - humblec
-  - Madhu-1


### PR DESCRIPTION
**Describe what this PR does**
This PR removes the OWNERS file.
- No automation currently uses this file
- Its contents do not reflect the roles in this repo
- Repo permissions are managed via the github groups
- PRs should be reviewed by a larger set of individuals than are currently present in this file


**Is there anything that requires special attention?**
N/A

**Related issues:**
N/A
