### PR TITLE
Makes gometalinter output periodic status updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,10 @@ script:
   - make vendor-install
   # Lint golang sources
   - >
-    gometalinter -j4 --sort=path --sort=line --sort=column
+    gometalinter -j1 --sort=path --sort=line --sort=column
     --exclude="method NodeGetId should be NodeGetID"
-    --deadline 1h --vendor ./...
+    --deadline 9m --vendor --debug ./...
+    |& stdbuf -oL awk '/linter took/ || !/^DEBUG/'
   # Build the code & run tests
   - make
   - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ env:
 go:
   # Kubernetes minimum_go_version can be found in this file:
   # https://github.com/kubernetes/kubernetes/blob/master/hack/lib/golang.sh
-  - master
   - stable
-  - "1.9.4"  # used by CentOS 7.5.1804
+  - "1.10.x"  # used by OCP releases
+  - "1.9.4"   # used by CentOS 7.5.1804
 
 install:
   - gem install asciidoctor mdl


### PR DESCRIPTION
**Describe what this PR does**
gometalinter, by default, doesn't send any output until it has all the
results from the linters. This change enables debug output, which
includes status messages as each linter completes. This will provide
periodic output so that Travis doesn't give up waiting for output. We
also change the linter deadline to 9 minutes (<10 min) to make it clear
when we have a problem.

This also swaps out golang builds master ==> 1.10.x since OCP builds w/ 1.10 and `gimme` in Travis seems to be having difficulty w/ fetching master.

**Related issues:**
Fixes #68 
