### PR TITLE
Properly preserve return code from gometalinter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ script:
   - make vendor-install
   # Lint golang sources
   - >
+    set -o pipefail;
     gometalinter -j1 --sort=path --sort=line --sort=column
     --exclude="method NodeGetId should be NodeGetID"
     --deadline 9m --vendor --debug ./...


### PR DESCRIPTION
Commit 4249bbd placed gometalinter into a pipeline when run in Travis to
output status as it proceeds. Unfortunately, this pipeline masked the
return code of gometalinter since it was not the last piped command.
This caused the linting to always pass. This fix sets the 'pipefail'
shell option to ensure non-zero exit status is preserved even when run
through the pipeline so that lint errors will properly return an error.

Signed-off-by: John Strunk <jstrunk@redhat.com>