### PR TITLE
Call Volume info instead of volume status API

### DIFF
--- a/pkg/glusterfs/driver_test.go
+++ b/pkg/glusterfs/driver_test.go
@@ -117,12 +117,13 @@ func handleGETRequest(w http.ResponseWriter, r *http.Request, t *testing.T) {
 		return
 	}
 
-	if strings.HasSuffix(r.URL.String(), "/v1/volumes") {
+	if r.URL.String() == "/v1/volumes" {
 		resp := make(api.VolumeListResp, 1)
 		resp[0] = api.VolumeGetResp{
 			ID:       id,
 			Name:     "test1",
 			Metadata: map[string]string{volumeOwnerAnn: glusterfsCSIDriverName},
+			State:    api.VolStarted,
 			Capacity: 1000,
 		}
 		writeResp(w, http.StatusOK, resp, t)
@@ -132,16 +133,12 @@ func handleGETRequest(w http.ResponseWriter, r *http.Request, t *testing.T) {
 
 	vol := strings.Split(strings.Trim(r.URL.String(), "/"), "/")
 	if checkVolume(vol[2]) {
-		resp := api.VolumeStatusResp{
-			Info: api.VolumeInfo{
-				ID:       id,
-				Name:     vol[2],
-				Metadata: map[string]string{volumeOwnerAnn: glusterfsCSIDriverName},
-			},
-			Online: true,
-			Size: api.SizeInfo{
-				Capacity: volumeCache[vol[2]],
-			},
+		resp := api.VolumeGetResp{
+			ID:       id,
+			Name:     vol[2],
+			Metadata: map[string]string{volumeOwnerAnn: glusterfsCSIDriverName},
+			State:    api.VolStarted,
+			Capacity: volumeCache[vol[2]],
 		}
 		writeResp(w, http.StatusOK, resp, t)
 		return


### PR DESCRIPTION


Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>

**Describe what this PR does**
After volume creation, suppose glusterd2 or CSI driver fails, as the volume is not in the started state we won't be able to get the volume status. As part of checking the existing volume we don't need to call
volume status API, we can call volume info and check volume is present or not.

**Is there anything that requires special attention?**
Do you have any questions? Did you do something clever?

**Related issues:**
Fixes #86 
