### PR TITLE
README: show the build status of the master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gluster-csi-driver
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/gluster/gluster-csi-driver)](https://goreportcard.com/report/github.com/gluster/gluster-csi-driver)
-[![Build Status](https://ci.centos.org/view/Gluster/job/gluster_csi-driver-smoke/badge/icon)](https://ci.centos.org/view/Gluster/job/gluster_csi-driver-smoke/)
+[![Build Status](https://ci.centos.org/view/Gluster/job/gluster_csi-driver-master/badge/icon)](https://ci.centos.org/view/Gluster/job/gluster_csi-driver-master/)
 
 This repo contains CSI driver for Gluster. The Container Storage Interface
 (CSI) is a proposed new industry standard for cluster-wide volume plugins.


### PR DESCRIPTION
**Describe what this PR does**

The current build status badge points to the smoke test that runs in the CentOS CI. The result of the smoke tests for a PR does not tell anything about the buildable status of the master branch.

A new job has been added to the CI to build the master branch after changes have been merged. The updated link of the badge points to the last build of the master branch now.

The 1st run was triggered manually to verify the job. It builds so the badge shows 'success' instead of 'unknown' (for jobs that did not run yet).

**Related issues:**
Fixes: #96 
See-also: gluster/centosci#38