### PR TITLE
Remove timeout from gml

### DIFF
--- a/scripts/lint-go.sh
+++ b/scripts/lint-go.sh
@@ -3,10 +3,11 @@
 set -o pipefail
 
 if [[ -x "$(command -v gometalinter)" ]]; then
-  # shellcheck disable=SC2086,SC2068
-  gometalinter -j ${GO_METALINTER_THREADS:-1} --sort path --sort line --sort column --deadline=9m \
+  gometalinter -j "${GO_METALINTER_THREADS:-1}" \
+    --sort path --sort line --sort column --deadline=24h \
     --enable="gofmt" --exclude "method NodeGetId should be NodeGetID" \
-    --vendor --debug ${@-./...} |& stdbuf -oL grep "linter took\\|:warning:\\|:error:"
+    --vendor --debug "${@-./...}" \
+  |& stdbuf -oL grep "linter took\\|:warning:\\|:error:"
 else
   echo "WARNING: gometalinter not found, skipping lint tests" >&2
 fi


### PR DESCRIPTION
**Describe what this PR does**
cloud.docker.com has been timing out when building the container, and it
looks like this may be due to the linter timing out. This removes the
timeout.

**Is there anything that requires special attention?**
I probably shouldn't have put in the timeout to start with. :disappointed: 

**Related issues:**
Fixes #128 