### PR TITLE
Pass Args from one stage to another  stage

### DIFF
--- a/pkg/glusterfs/Dockerfile
+++ b/pkg/glusterfs/Dockerfile
@@ -21,6 +21,10 @@ ENV GOPATH="/go/" \
 RUN yum install -y \
     git
 
+# The version of the driver (git describe --dirty --always --tags | sed 's/-/./2' | sed 's/-/./2')
+ARG version="(unknown)"
+# Container build time (date -u '+%Y-%m-%dT%H:%M:%S.%NZ')
+ARG builddate="(unknown)"
 # Install go tools
 ARG GO_DEP_VERSION=
 ARG GO_METALINTER_VERSION=latest
@@ -70,9 +74,9 @@ RUN yum -y install glusterfs-fuse && \
 # Copy glusterfs-csi-driver from build phase
 COPY --from=build /build /
 
-# The version of the driver (git describe --dirty --always --tags | sed 's/-/./2' | sed 's/-/./2')
+# The version of the driver
 ARG version="(unknown)"
-# Container build time (date -u '+%Y-%m-%dT%H:%M:%S.%NZ')
+# Container build time
 ARG builddate="(unknown)"
 
 LABEL build-date="${builddate}"


### PR DESCRIPTION
An ARG instruction goes out of scope at the end of the build stage where it was defined.
To use an arg in multiple stages, each stage must include the ARG instruction.
More info: https://docs.docker.com/engine/reference/builder/#scope
Fixes: #98

Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>

output:
```
Labels": {
                "Summary": "FUSE-based CSI driver for Gluster file access",
                "build-date": "2019-01-10T17:35:24.988988941Z",
                "io.k8s.description": "FUSE-based CSI driver for Gluster file access",
                "name": "glusterfs-csi-driver",
                "org.label-schema.schema-version": "= 1.0     org.label-schema.name=CentOS Base Image     org.label-schema.vendor=CentOS     org.label-schema.license=GPLv2     org.label-schema.build-date=20180531",
                "vcs-type": "git",
                "vcs-url": "https://github.com/gluster/gluster-csi-driver",
                "vendor": "gluster.org",
                "version": "1.0.0-pre.0.12.g4af48ca"
            }

```