### PR TITLE
Remove UNKNOWN capabilities

### DIFF
--- a/pkg/glusterfs/nodeserver.go
+++ b/pkg/glusterfs/nodeserver.go
@@ -157,18 +157,5 @@ func (ns *NodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 
 // NodeGetCapabilities returns the supported capabilities of the node server
 func (ns *NodeServer) NodeGetCapabilities(ctx context.Context, req *csi.NodeGetCapabilitiesRequest) (*csi.NodeGetCapabilitiesResponse, error) {
-	// currently there is a single NodeServer capability according to the spec
-	nscap := &csi.NodeServiceCapability{
-		Type: &csi.NodeServiceCapability_Rpc{
-			Rpc: &csi.NodeServiceCapability_RPC{
-				Type: csi.NodeServiceCapability_RPC_UNKNOWN,
-			},
-		},
-	}
-	glog.V(1).Infof("node capabiilities: %+v", nscap)
-	return &csi.NodeGetCapabilitiesResponse{
-		Capabilities: []*csi.NodeServiceCapability{
-			nscap,
-		},
-	}, nil
+	return &csi.NodeGetCapabilitiesResponse{}, nil
 }


### PR DESCRIPTION
This PR removes the return of UNKNOWN capabilities for node service capabilities

as we are not supporting below capabilities of node service, it's perfectly fine to return an empty response.

NodeServiceCapability_RPC_GET_VOLUME_STATS
NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME

Fixes #147

Signed-off-by: Madhu Rajanna <mrajanna@redhat.com>
