### PR TITLE
Automatically build virtblock driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,13 +9,56 @@ addons:
       - realpath
       - ruby
 
-install:
-  - gem install asciidoctor mdl
-  - pip install --user --upgrade pip
-  - pip install --user yamllint
-
-script:
-  # Lint text-like files
-  - scripts/lint-text.sh --require-all
-  # Build container w/ Docker
-  - ./build.sh
+jobs:
+  include:
+    - name: Linter
+      install:
+        - gem install asciidoctor mdl
+        - pip install --user --upgrade pip
+        - pip install --user yamllint
+      script:
+        - scripts/lint-text.sh --require-all
+    - name: glusterfs-csi-driver
+      script:
+        - ./build.sh glusterfs
+      deploy:
+        # Master branch will push the container to :latest
+        - provider: script
+          on:  # yamllint disable-line rule:truthy
+            branch: master
+          script: >
+            .travis/push_container.sh
+            gluster/glusterfs-csi-driver
+            verbatim latest
+        # Tags of the form v + SEMVER (e.g., v1.2.3) will push to the
+        # corresponding container version number (e.g., :1.2.3).
+        - provider: script
+          on:  # yamllint disable-line rule:truthy
+            tags: true
+            condition: $TRAVIS_TAG =~ ^v[0-9]+
+          script: >
+            .travis/push_container.sh
+            gluster/glusterfs-csi-driver
+            version "$TRAVIS_TAG"
+    - name: glustervirtblock-csi-driver
+      script:
+        - ./build.sh glustervirtblock
+      deploy:
+        # Master branch will push the container to :latest
+        - provider: script
+          on:  # yamllint disable-line rule:truthy
+            branch: master
+          script: >
+            .travis/push_container.sh
+            gluster/glustervirtblock-csi-driver
+            verbatim latest
+        # Tags of the form v + SEMVER (e.g., v1.2.3) will push to the
+        # corresponding container version number (e.g., :1.2.3).
+        - provider: script
+          on:  # yamllint disable-line rule:truthy
+            tags: true
+            condition: $TRAVIS_TAG =~ ^v[0-9]+
+          script: >
+            .travis/push_container.sh
+            gluster/glustervirtblock-csi-driver
+            version "$TRAVIS_TAG"

--- a/.travis/push_container.sh
+++ b/.travis/push_container.sh
@@ -1,0 +1,27 @@
+#! /bin/bash
+
+# Usage: push_container.sh <repo> <verbatim|version> <tag>
+set -e -o pipefail
+
+image="$1"
+
+if [[ "x$2" == "xversion" ]]; then
+        [[ "$3" =~ ^v([0-9]+.*) ]] || exit 1;
+        tag="${BASH_REMATCH[1]}"
+else
+        tag="$3"
+fi
+
+if [[ "x${QUAY_USERNAME}" != "x" && "x${QUAY_PASSWORD}" != "x" ]]; then
+        echo "$QUAY_PASSWORD" | docker login -u "$QUAY_USERNAME" --password-stdin quay.io
+        finalimage="quay.io/$image:$tag"
+        docker tag "$image" "$finalimage"
+        docker push "$finalimage"
+fi
+
+if [[ "x${DOCKER_USERNAME}" != "x" && "x${DOCKER_PASSWORD}" != "x" ]]; then
+        echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin docker.io
+        finalimage="docker.io/$image:$tag"
+        docker tag "$image" "$finalimage"
+        docker push "$finalimage"
+fi

--- a/build.sh
+++ b/build.sh
@@ -1,15 +1,16 @@
 #! /bin/bash
 
-set -e
+set -e -o pipefail
 
-# Set driver name
-DRIVER="${DRIVER:-glusterfs-csi-driver}"
-
-# Set which docker repo to tag
-REPO="${REPO:-gluster/}"
+# Set which docker repo to use
+REPO="${REPO:-gluster}"
 
 # Allow overriding default docker command
 RUNTIME_CMD=${RUNTIME_CMD:-docker}
+
+GO_DEP_VERSION="${GO_DEP_VERSION}"
+GO_METALINTER_VERSION="${GO_METALINTER_VERSION:-v3.0.0}"
+GO_METALINTER_THREADS=${GO_METALINTER_THREADS:-4}
 
 build="build"
 if [[ "${RUNTIME_CMD}" == "buildah" ]]; then
@@ -19,12 +20,65 @@ fi
 # Allow disabling tests during build
 RUN_TESTS=${RUN_TESTS:-1}
 
-VERSION="$(git describe --dirty --always --tags | sed 's/-/./2' | sed 's/-/./2')"
+SCRIPT=$(basename "$0")
+
+function usage {
+	cmd="$1"
+	cat - <<USAGE
+Usage: $cmd <drivername>
+
+Available drivers:
+    glusterfs
+    glustervirtblock
+USAGE
+}
+
+if [[ $# -ne 1 ]]; then
+	echo "ERROR: No driver name specified."
+	usage "$SCRIPT"
+	exit 1
+fi
+
+case $1 in
+glusterfs)
+	DRIVER=glusterfs-csi-driver
+	DOCKERFILE=pkg/glusterfs/Dockerfile
+	;;
+glustervirtblock)
+	DRIVER=glustervirtblock-csi-driver
+	DOCKERFILE=pkg/gluster-virtblock/Dockerfile
+	;;
+*)
+	echo "ERROR: Invalid driver name specified."
+	usage "$SCRIPT"
+	exit 1
+	;;
+esac
+
+
+# This sets the version variable to (hopefully) a semver compatible string. We
+# expect released versions to have a tag of vX.Y.Z (with Y & Z optional), so we
+# only look for those tags. For version info on non-release commits, we want to
+# include the git commit info as a "build" suffix ("+stuff" at the end). There
+# is also special casing here for when no tags match.
+VERSION_GLOB="v[0-9]*"
+# Get the nearest "version" tag if one exists. If not, this returns the full
+# git hash
+NEAREST_TAG="$(git describe --always --tags --match "$VERSION_GLOB" --abbrev=0)"
+# Full output of git describe for us to parse: TAG-<N>-g<hash>-<dirty>
+FULL_DESCRIBE="$(git describe --always --tags --match "$VERSION_GLOB" --dirty)"
+# If full matches against nearest, we found a valid tag earlier
+if [[ $FULL_DESCRIBE =~ ${NEAREST_TAG}-(.*) ]]; then
+        # Build suffix is the last part of describe w/ "-" replaced by "."
+        VERSION="$NEAREST_TAG+${BASH_REMATCH[1]//-/.}"
+else
+        # We didn't find a valid tag, so assume version 0 and everything ends up
+        # in build suffix.
+        VERSION="0.0.0+g${FULL_DESCRIBE//-/.}"
+fi
+
 BUILDDATE="$(date -u '+%Y-%m-%dT%H:%M:%S.%NZ')"
 
-GO_DEP_VERSION="${GO_DEP_VERSION}"
-GO_METALINTER_VERSION="${GO_METALINTER_VERSION:-v2.0.12}"
-GO_METALINTER_THREADS=${GO_METALINTER_THREADS:-4}
 
 build_args=()
 build_args+=(--build-arg "RUN_TESTS=$RUN_TESTS")
@@ -40,32 +94,16 @@ $RUNTIME_CMD version
 
 #-- Build glusterfs csi driver container
 $RUNTIME_CMD $build \
-	-t "${REPO}${DRIVER}" \
+	-t "${REPO}/${DRIVER}" \
 	"${build_args[@]}" \
-	-f pkg/glusterfs/Dockerfile \
+	--network host \
+	-f "$DOCKERFILE" \
 	. ||
 	exit 1
 
 # If running tests, extract profile data
 if [ "$RUN_TESTS" -ne 0 ]; then
 	rm -f profile.cov
-	$RUNTIME_CMD run --entrypoint cat "${REPO}${DRIVER}" \
-		/profile.cov >profile.cov
-fi
-
-DRIVER="glustervirtblock-csi-driver"
-
-#-- Build gluster block csi driver container
-$RUNTIME_CMD $build \
-	-t "${REPO}${DRIVER}" \
-	"${build_args[@]}" \
-	-f pkg/gluster-virtblock/Dockerfile \
-	. ||
-	exit 1
-
-# If running tests, extract profile data
-if [ "$RUN_TESTS" -ne 0 ]; then
-	rm -f profile.cov
-	$RUNTIME_CMD run --entrypoint cat "${REPO}${DRIVER}" \
+	$RUNTIME_CMD run --entrypoint cat "${REPO}/${DRIVER}" \
 		/profile.cov > profile.cov
 fi

--- a/docs/ci-infrastructure.md
+++ b/docs/ci-infrastructure.md
@@ -15,17 +15,19 @@ The tests that are run include:
 - Running linters over the text-like files in the repo (bash, md, yaml, etc.)
 - Building the code with recent versions of golang
 - Running a number of code linters over the source (via [gometalinter](https://github.com/alecthomas/gometalinter))
-- Building the container image via Docker
+- Building the container images via Docker
 
 ### Configuration
 
 The configuration for Travis is controlled by the
 [.travis.yml](https://github.com/gluster/gluster-csi-driver/blob/master/.travis.yml)
-file in the main directory of the repo. Briefly, there is one job for each
-golang version listed in the file. Within each job, the "install" steps are
-executed in order, followed by the "script" steps. If any command fails, the
-job will register a failure. See the main Travis documentation for details on
-the configuration file.
+file in the main directory of the repo. Briefly, there is one job for each type
+of CSI driver. Within each job, the "install" steps are executed in order,
+followed by the "script" steps. If the CI job is running against `master` or a
+tag of the form 'v[0-9]+', the deploy step will execute, pushing the built
+containers to both Quay and Docker hub. If any command fails, the job will
+register a failure. See the main Travis documentation for details on the
+configuration file.
 
 ### Troubleshooting
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -45,8 +45,10 @@ and it must be backward compatible.
 
 ## Tagging repositories
 
-The tag name (`$tag` in the previous example) must conform
-to the [versioning](#versioning) requirements (e.g. `1.0.0-rc2`).
+The tag name must begin with "v" followed by the version number, conforming to
+the [versioning](#versioning) requirements (e.g. a tag of `v1.0.0-rc2` for
+version `1.0.0-rc2`). This tag format is used by the Travis CI infrastructure to
+properly upload and tag releases to Quay and Docker Hub.
 
 ## Release process
 

--- a/scripts/lint-go.sh
+++ b/scripts/lint-go.sh
@@ -7,7 +7,7 @@ if [[ -x "$(command -v gometalinter)" ]]; then
     --sort path --sort line --sort column --deadline=24h \
     --enable="gofmt" --exclude "method NodeGetId should be NodeGetID" \
     --vendor --debug "${@-./...}" \
-  |& stdbuf -oL grep "linter took\\|:warning:\\|:error:"
+  |& stdbuf -oL awk '/linter took/ || !/^DEBUG/ || /nolint:/'
 else
   echo "WARNING: gometalinter not found, skipping lint tests" >&2
 fi


### PR DESCRIPTION
**Describe what this PR does**
This PR changes the build process to separate the building of the two CSI drivers. The name of the driver is now passed to the `./build.sh` command to build the appropriate container.

Usage:
```
$ ./build.sh 
ERROR: No driver name specified.
Usage: build.sh <drivername>

Available drivers:
    glusterfs
    glustervirtblock
```

This also updates Travis to have separate jobs for each driver, and it adds a deploy step to the end of each job to push the containers to Quay.
Since we are now building the containers in Travis, the resulting containers now have the proper version information. This is only a partial solution to #98 since the docker hub container is not fixed.

**Is there anything that requires special attention?**
Do you have any questions? Did you do something clever?

**Related issues:**
Fixes #157 
