### PR TITLE
Fix wrong container tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
         - provider: script
           on:  # yamllint disable-line rule:truthy
             branch: master
-          script: >
+          script: >-
             .travis/push_container.sh
             gluster/glusterfs-csi-driver
             verbatim latest
@@ -36,7 +36,7 @@ jobs:
           on:  # yamllint disable-line rule:truthy
             tags: true
             condition: $TRAVIS_TAG =~ ^v[0-9]+
-          script: >
+          script: >-
             .travis/push_container.sh
             gluster/glusterfs-csi-driver
             version "$TRAVIS_TAG"
@@ -48,7 +48,7 @@ jobs:
         - provider: script
           on:  # yamllint disable-line rule:truthy
             branch: master
-          script: >
+          script: >-
             .travis/push_container.sh
             gluster/glustervirtblock-csi-driver
             verbatim latest
@@ -58,7 +58,7 @@ jobs:
           on:  # yamllint disable-line rule:truthy
             tags: true
             condition: $TRAVIS_TAG =~ ^v[0-9]+
-          script: >
+          script: >-
             .travis/push_container.sh
             gluster/glustervirtblock-csi-driver
             version "$TRAVIS_TAG"


### PR DESCRIPTION
**Describe what this PR does**
Due to an error in line wrapping in the .travis.yml file, the master
branch was being pushed to "latestn" tag instead of "latest". This fixes
the yaml by removing the final line break in the wrapping.

**Is there anything that requires special attention?**
no

**Related issues:**
