### PR TITLE
Storage class option for Loopback bricks

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -43,7 +43,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:4e3b3219f72e9603e9966c32878de84bbfd9d2fc5707fcd50a2ea94fd4a7b60a"
+  digest = "1:fccd76e2ec9df3825e1c59832d0117e05f2d303f18febb28139bb7df2a14f6d9"
   name = "github.com/gluster/glusterd2"
   packages = [
     "pkg/api",
@@ -56,9 +56,10 @@
     "plugins/events/api",
     "plugins/georeplication/api",
     "plugins/glustershd/api",
+    "plugins/tracemgmt/api",
   ]
   pruneopts = "NUT"
-  revision = "445cdb9256c30f1992a47149bfa613f314eac5f9"
+  revision = "17bc6f49cc90b46664f05697e92dba897194bc4a"
 
 [[projects]]
   digest = "1:abea725bcf0210887f5da19d804fffa1dd45a42a56bdf5f02322345e3fee4f0d"

--- a/README.md
+++ b/README.md
@@ -633,6 +633,61 @@ root@redis-pvc-restore:/mnt/gluster# cat clone_data
 glusterfs csi clone test
 ```
 
+### Create a glusterfs lite storage class to use loopback bricks (RWX)
+
+```
+[root@localhost]# cat glusterfs-lite-storage-class.yaml
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: glusterfs-lite-csi
+provisioner: org.gluster.glusterfs
+parameters:
+  brickType: "loop"
+```
+
+```
+[root@localhost]# kubectl create -f glusterfs-lite-storage-class.yaml
+storageclass.storage.k8s.io/glusterfs-lite-csi created
+```
+
+Verify glusterfs storage class (RWX)
+
+```
+[root@localhost]# kubectl get storageclass
+NAME                      PROVISIONER             AGE
+glusterfs-lite-csi        org.gluster.glusterfs   105s
+```
+
+### Create RWX PersistentVolumeClaim using glusterfs-lite-csi storage class
+
+```
+[root@localhost]# cat pvc.yaml
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: glusterfs-lite-csi-pv
+spec:
+  storageClassName: glusterfs-lite-csi
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 5Gi
+
+[root@localhost]# kubectl create -f pvc.yaml
+persistentvolumeclaim/glusterfs-lite-csi-pv created
+```
+
+Validate the RWX claim creation
+
+```
+[root@localhost]# kubectl get pvc
+NAME                    STATUS    VOLUME                 CAPACITY   ACCESS MODES   STORAGECLASS         AGE
+glusterfs-lite-csi-pv   Bound     pvc-943d21f5a51312e7   5Gi        RWX            glusterfs-lite-csi   5s
+```
+
 #### Create PVC with thin arbiter support
 
 follow [guide](

--- a/examples/kubernetes/glusterfs/glusterfs-lite-pvc.yaml
+++ b/examples/kubernetes/glusterfs/glusterfs-lite-pvc.yaml
@@ -1,0 +1,12 @@
+---
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: glusterfs-lite-csi-pv
+spec:
+  storageClassName: glusterfs-lite-csi
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 5Gi

--- a/examples/kubernetes/glusterfs/glusterfs-lite-storage-class.yaml
+++ b/examples/kubernetes/glusterfs/glusterfs-lite-storage-class.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: glusterfs-lite-csi
+provisioner: org.gluster.glusterfs
+parameters:
+  brickType: "loop"


### PR DESCRIPTION
With this glusterd2
[PR](gluster/glusterd2#1473), Auto provisioned
bricks can be created using loopback devices as an alternative to LVM
devices.

Glusterd2 Volume create API now accepts a new option called
`ProvisionerType`(default value is `lvm`). If `ProvisionerType=loop`
then Glusterd2 will create the loopback device, mounts, and uses as
brick.

Similar to LVM based provisioning, loop provisioning also requires
registering the mounted file system to be registered as below,

```
glustercli device add <peerid> <path> --provisioner loop
```

Example:

```
glustercli device add 70d79c3f-e7af-43f6-8b65-05dff2423da1 \
	   /exports --provisioner loop
```

Now create the volume using,

```
glustercli volume create gv1 --size 1G \
	   --provisioner loop \
	   --replica 3
```

With this PR, new option is introduced for CSI driver to support the
loopback bricks, which can be customized by creating new storage
class.