### PR TITLE
gluster-virtblock: Fix stale mounts of block host volume

### DIFF
--- a/pkg/gluster-virtblock/config/config.go
+++ b/pkg/gluster-virtblock/config/config.go
@@ -1,20 +1,26 @@
 package config
 
+// MntInfo struct has information about the block host volume mount path
+type MntInfo struct {
+	MntPath  string
+	RefCount int
+}
+
 // Config struct fills the parameters of request or user input
 type Config struct {
-	Endpoint      string            // CSI endpoint
-	NodeID        string            // CSI node ID
-	RestURL       string            // GD2 endpoint
-	RestUser      string            // GD2 user name who has access to create and delete volume
-	RestSecret    string            // GD2 user password
-	RestTimeout   int               // GD2 rest client timeout
-	Mounts        map[string]string // List of volumes and mount paths
-	MntPathPrefix string            // Path under which gluster block host volumes will be mounted
+	Endpoint      string              // CSI endpoint
+	NodeID        string              // CSI node ID
+	RestURL       string              // GD2 endpoint
+	RestUser      string              // GD2 user name who has access to create and delete volume
+	RestSecret    string              // GD2 user password
+	RestTimeout   int                 // GD2 rest client timeout
+	Mounts        map[string]*MntInfo // List of volumes and mount paths
+	MntPathPrefix string              // Path under which gluster block host volumes will be mounted
 }
 
 //NewConfig returns config struct to initialize new driver
 func NewConfig() *Config {
 	var conf Config
-	conf.Mounts = make(map[string]string)
+	conf.Mounts = make(map[string]*MntInfo)
 	return &conf
 }


### PR DESCRIPTION
Currently in gluster-virtblock nodeplugin, the block host volume is
not unmounted even after all the block volumes in that block host volume
is unmounted/deleted. With this patch the above mentioned behaviour is
fixed.

Signed-off-by: Poornima G <pgurusid@redhat.com>

**Describe what this PR does**
Provide some context for the reviewer

**Is there anything that requires special attention?**
Do you have any questions? Did you do something clever?

**Related issues:**
Mention any github issues relevant to this PR
